### PR TITLE
Fix problema con hie.yaml en Windows con Simple GHC

### DIFF
--- a/pages/haskell/troubleshooting.md
+++ b/pages/haskell/troubleshooting.md
@@ -48,6 +48,16 @@ Si al intentar ejecutar `stack build`, `stack test` o cualquier otro comando sta
 > El antivirus también puede causar que el comando stack build/test tarde (porque analiza los archivos que genera stack). Lo recomendable es desactivarlo al menos para la carpeta del proyecto donde estés.
 
 
+### Simple GHC en Visual Studio Code no me muestra los tipos de las cosas
+
+Lo que hace Simple GHC debería poder encontrarse en View > Output > GHC. Si no ves nada ahí y estás en Windows, el problema puede ser un archivo llamado `hie.yaml` en la raíz del proyecto (misma carpeta donde están el `stack.yaml` y el `package.yaml`).
+Probá cambiar los contenidos de ese archivo a:
+```yaml
+cradle:
+  stack:
+```
+Y cerrá y abrí vscode.
+
 ### Problemas con Sistemas Operativos de 32 bits
 
 Si al intentar ejecutar `stack build`, `stack test` o cualquier otro comando stack te aparece un mensaje de error que dice:


### PR DESCRIPTION
Maiu se dio cuenta de que en Windows Simple GHC no funcionaba bien y pareciera ser por esto:
https://github.com/dramforever/vscode-ghc-simple/issues/91

Estoy probando alternativas de `hie.yaml` que anden porque parece que el problema es cuando se listan múltiples componentes